### PR TITLE
Enable add and remove array scalar fields

### DIFF
--- a/grapi-mongodb/package.json
+++ b/grapi-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalars/grapi-mongodb",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "description": "The mongodb package of Grapi",
   "main": "./lib/index.js",
   "module": "./lib/index.js",
@@ -35,7 +35,7 @@
   "author": "madrov",
   "license": "Apache-2.0",
   "dependencies": {
-    "@scalars/grapi": "^2.1.8",
+    "@scalars/grapi": "^2.2.0",
     "mongodb": "^3.6.9",
     "mongodb-client-encryption": "^1.2.4"
   },

--- a/grapi-mongodb/src/mongodbDataSource.ts
+++ b/grapi-mongodb/src/mongodbDataSource.ts
@@ -57,11 +57,11 @@ export class MongodbDataSource extends MongodbData implements DataSource {
     }
 
     public async update( where: Where, mutation: Mutation ): Promise<any> {
-        const payload = this.transformMutation( mutation )
+        const payload = this.transformMutation( mutation, true )
         const filterQuery = this.whereToFilterQuery( where )
         if ( isEmpty( payload ) === false ) {
             try {
-                await this.db.collection( this.collectionName ).updateOne( filterQuery, { $set: payload } )
+                await this.db.collection( this.collectionName ).updateOne( filterQuery, payload )
             } catch ( error ) {
                 this.handleMongoDbError( error )
             }

--- a/grapi/package.json
+++ b/grapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalars/grapi",
-  "version": "2.1.9",
+  "version": "2.2.0",
   "description": "Grapi Schema Generator For GraphQL Server",
   "keywords": [
     "grapi",

--- a/grapi/src/plugins/create.ts
+++ b/grapi/src/plugins/create.ts
@@ -105,8 +105,7 @@ const createInputField = (
             let fieldType: string
             if ( field.isList() ) {
                 // wrap with set field
-                const fieldWithPrefix = `${capName}${upperFirst( name )}`
-                const listOperationInput = `${fieldWithPrefix}CreateInput`
+                const listOperationInput = `${field.getTypename()}ListFieldCreateInput`
                 root.addInput(
                     `input ${listOperationInput} {
                         set: [${field.getTypename()}]

--- a/grapi/src/plugins/mutation.ts
+++ b/grapi/src/plugins/mutation.ts
@@ -1,6 +1,6 @@
 // tslint:disable:max-classes-per-file
-import { Mutation } from '..'
-import { forEach, get, isEmpty, omit, pick } from '../lodash'
+import { ArrayOperator, Mutation } from '..'
+import { forEach, isEmpty, omit, pick } from '../lodash'
 
 const mutationWithoutArrayField = ( originPayload: any ): Mutation => {
     const payload = { ...originPayload }
@@ -33,17 +33,31 @@ export class PluginMutation implements Mutation {
         const arrayFieldData = pick( this.payload, this.arrayFields )
         const operations = []
         forEach( arrayFieldData, ( operationValue, fieldName ) => {
-            const value = get( operationValue, 'set' )
-            if ( !value ) {
-                return
+            const setValue = operationValue[ArrayOperator.set]
+            if ( setValue ) {
+                operations.push( {
+                    fieldName,
+                    operator: ArrayOperator.set,
+                    value: setValue,
+                } )
             }
-            operations.push( {
-                fieldName,
-                operator: 'set',
-                value,
-            } )
+            const addValue = operationValue[ArrayOperator.add]
+            if ( addValue ) {
+                operations.push( {
+                    fieldName,
+                    operator: ArrayOperator.add,
+                    value: addValue,
+                } )
+            }
+            const removeValue = operationValue[ArrayOperator.remove]
+            if ( removeValue ) {
+                operations.push( {
+                    fieldName,
+                    operator: ArrayOperator.remove,
+                    value: removeValue,
+                } )
+            }
         } )
-
         return operations
     };
 }

--- a/grapi/src/plugins/update.ts
+++ b/grapi/src/plugins/update.ts
@@ -48,7 +48,6 @@ const createInputField = (
     recursive: boolean = true
 ): string[] => {
     const { root } = context
-    const capName = model.getNamings().capitalSingular
     const fields = model.getFields()
     const content: string[] = []
     const mutationFactory = getMutationFactoryFromModel( model )
@@ -118,11 +117,12 @@ const createInputField = (
             let fieldType: string
             if ( field.isList() ) {
                 // wrap with set field
-                const fieldWithPrefix = `${capName}${upperFirst( name )}`
-                const listOperationInput = `${fieldWithPrefix}UpdateInput`
+                const listOperationInput = `${field.getTypename()}ListFieldUpdateInput`
                 root.addInput(
                     `input ${listOperationInput} {
                         set: [${field.getTypename()}]
+                        add: [${field.getTypename()}]
+                        remove: [${field.getTypename()}]
                     }`
                 )
                 fieldType = listOperationInput

--- a/grapi/test/fixtures/scalarListInput.graphql
+++ b/grapi/test/fixtures/scalarListInput.graphql
@@ -1,0 +1,12 @@
+scalar Url
+scalar Email
+scalar DateTime
+scalar Json
+
+type User @Model(dataSource: "memory", key: "users_scalar_list"){
+    id: ID! @unique @autoGen
+    name: String! @unique
+    hobbies: [ String ]
+    phones: [ Int ]
+    friends: [ Json ]
+}

--- a/grapi/test/scalarListInput.spec.ts
+++ b/grapi/test/scalarListInput.spec.ts
@@ -1,0 +1,63 @@
+import chai from 'chai'
+import chaiHttp = require( 'chai-http' );
+chai.use( chaiHttp )
+
+import { sdl, testSuits } from './testsuites/scalarListInput'
+import { createGrapiApp, MongodbDataSourceGroup, prepareConfig } from './testsuites/utils'
+
+const { mongoUri } = prepareConfig()
+const DB_NAME = 'grapi'
+
+const data = [
+    {
+        'name': 'Ben Bohm',
+        hobbies: { set: [ 'Video Games', 'Guitar', 'Bicycle' ] },
+        phones: { set: [ 1, 2, 3 ] },
+        friends: { set: [ { name: 'Jhon Doe' } ] }
+    },
+    {
+        'name': 'Wout Beckers',
+        hobbies: { set: [ 'Video Games', 'Guitar', 'Bicycle', 'Movies', 'Programming' ] },
+        phones: { set: [ 1, 2, 3, 45, 50, 100 ] },
+        friends: { set: [ { name: 'Maria Doe' }, { name: 'Jhon Doe' } ] }
+    },
+    {
+        'name': 'Michela Battaglia',
+        hobbies: { set: [ 'Video Games', 'Guitar', 'Bicycle' ] },
+        phones: { set: [ 1, 2, 3 ] },
+        friends: { set: [ { name: 'Fake Doe' } ] }
+    }
+]
+
+describe( 'Tests on fixtures/scalarListInput.graphql mongodatasource', function() {
+    this.timeout( 20000 )
+
+    before( async () => {
+        const mongodbDataSourceGroup = new MongodbDataSourceGroup( mongoUri, DB_NAME )
+        await mongodbDataSourceGroup.initialize()
+        const { graphqlRequest, close } = createGrapiApp( sdl, {
+            memory: args => mongodbDataSourceGroup.getDataSource( args.key ),
+        } )
+        const query: string = `mutation ( $data: UserCreateInput! ) {
+            createUser(
+                data: $data
+            ) { id }
+        }`
+        await graphqlRequest( query, { data: data[0] } )
+        await graphqlRequest( query, { data: data[1] } );
+        ( this as any ).graphqlRequest = graphqlRequest;
+        ( this as any ).close = close;
+        ( this as any ).mongodb = ( mongodbDataSourceGroup as any ).db
+    } )
+
+    after( async () => {
+        const listCollectionsQuery = await ( this as any ).mongodb.listCollections()
+        const collections = await listCollectionsQuery.toArray()
+        await Promise.all( collections.map( async collection => {
+            await ( this as any ).mongodb.collection( collection.name ).deleteMany( {} )
+        } ) )
+        await ( this as any ).close()
+    } )
+
+    testSuits.call( this )
+} )

--- a/grapi/test/testsuites/scalarListInput.ts
+++ b/grapi/test/testsuites/scalarListInput.ts
@@ -1,0 +1,63 @@
+import chai from 'chai'
+import { readFileSync } from 'fs'
+import path from 'path'
+const expect = chai.expect
+
+const userFields = `
+  name
+  hobbies
+  phones
+  friends
+`
+
+const userName = 'Ben Bohm'
+const updateBen = `mutation (
+    $where: UserWhereUniqueInput!
+    $data: UserUpdateInput!
+) {
+    updateUser( 
+        where: $where 
+        data: $data 
+    ) { ${userFields} }
+}`
+
+export const sdl = readFileSync( path.resolve( __dirname, '../fixtures/scalarListInput.graphql' ), { encoding: 'utf8' } )
+
+export function testSuits() {
+
+    it( 'Should pass "add" int, string and json list', async ()  => {
+        const updateBenVariables = {
+            where: { name: userName  },
+            data: {
+                phones: { add: [ 45, 50, 100 ] },
+                hobbies: { add: [ 'Movies', 'Programming' ] },
+                friends: { add: [ { name: 'Maria Doe' }  ] }
+            }
+        }
+        const res = await ( this as any ).graphqlRequest( updateBen, updateBenVariables )
+        expect( res.updateUser ).to.deep.include( {
+            name: userName,
+            phones: [ 1, 2, 3, 45, 50, 100 ],
+            hobbies: [ 'Video Games', 'Guitar', 'Bicycle', 'Movies', 'Programming' ],
+            friends: [ { name: 'Jhon Doe' }, { name: 'Maria Doe' } ]
+        } )
+    } )
+
+    it( 'Should pass "remove" int, string and json list', async ()  => {
+        const updateBenVariables = {
+            where: { name: 'Wout Beckers'  },
+            data: {
+                phones: { remove: [ 1, 2, 3 ] },
+                hobbies: { remove: [ 'Video Games', 'Guitar', 'Bicycle' ] },
+                friends: { remove: [ { name: 'Jhon Doe' } ] }
+            }
+        }
+        const res = await ( this as any ).graphqlRequest( updateBen, updateBenVariables )
+        expect( res.updateUser ).to.deep.include( {
+            name: 'Wout Beckers',
+            phones: [ 45, 50, 100 ],
+            hobbies: [ 'Movies', 'Programming' ],
+            friends: [ { name: 'Maria Doe' } ]
+        } )
+    } )
+}


### PR DESCRIPTION
Closes #11 

```graphql
type Person @Model() {
    id: ID ! @unique
    skills: [ Json ! ] !
}
```

Now on mutation resolver updatePerson you can add or remove items embebded on skills attribute.

```graphql
mutation {
    updatePerson(
        where: { id: "" }
        data: { 
            skills: { 
                remove: [ { name: "Dance" }, { name: "Sing" } ]  
            } 
        }
    ) {
        id
        skills
    }
}

# or remove

mutation {
    updatePerson(
        where: { id: "" }
        data: { 
            skills: { 
                remove: [ { name: "Dance" }, { name: "Sing" } ]  
            } 
        }
    ) {
        id
        skills
    }
}
```